### PR TITLE
fix: 1.51.0

### DIFF
--- a/src/components/Nav/tabs.tsx
+++ b/src/components/Nav/tabs.tsx
@@ -89,7 +89,7 @@ export const NavTabsSlider: React.FC<TabsProps> = (props: React.PropsWithChildre
     );
   };
 
-  const handleIconClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  const handleIconClick = (event: React.MouseEvent<HTMLElement>) => {
     const iconId = event.currentTarget.id;
     const tabsBox = tabsBoxRef.current;
     if (!tabsBox) return;
@@ -200,12 +200,12 @@ export const NavTabsSlider: React.FC<TabsProps> = (props: React.PropsWithChildre
         </ul>
         {isWithButton && (
           <div className="icons-container">
-            <div className="right-left icon" onClick={handleIconClick} id="left">
+            <button className="right-left icon" onClick={handleIconClick} id="left">
               <span className="material-icons-round">arrow_back_ios</span>
-            </div>
-            <div className="right-left icon" onClick={handleIconClick} id="right">
+            </button>
+            <button className="right-left icon" onClick={handleIconClick} id="right">
               <span className="material-icons-round">arrow_forward_ios</span>
-            </div>
+            </button>
           </div>
         )}
       </nav>

--- a/src/get-started/GetStarted.stories.tsx
+++ b/src/get-started/GetStarted.stories.tsx
@@ -32,7 +32,7 @@ export const Instalacion = (): JSX.Element => (
       </p>
       {/* VER DOCUMENTACION */}
       <h2>
-        <a href="https://gcba.github.io/estandares/componentes/web/">Ver la documentación de componentes</a>.
+        <a href="https://gcba.github.io/estandares/componentes/acceso/">Ver la documentación de componentes</a>.
       </h2>
       <br />
 

--- a/src/organisms/Table/Table.stories.scss
+++ b/src/organisms/Table/Table.stories.scss
@@ -1,0 +1,3 @@
+.storybook__container-table-responsive {
+    max-width: 500px;
+}

--- a/src/organisms/Table/Table.stories.tsx
+++ b/src/organisms/Table/Table.stories.tsx
@@ -1,5 +1,6 @@
 // Base
 import React from 'react';
+import './Table.stories.scss';
 
 // Addons
 import { withA11y } from '@storybook/addon-a11y';
@@ -166,4 +167,22 @@ const rightAligned = (content: TableCellContet) => {
     content,
     props: { className: 'text-right' }
   };
+};
+
+export const Responsive = (): JSX.Element => {
+  return (
+    <div className="storybook__container-table-responsive">
+      <div className="table-responsive">
+        <Table
+          head={['#', 'Nombre', 'Apellido', 'Dirección', 'Ciudad', 'Comuna', 'Provincia']}
+          body={[
+            ['1', 'Juan', 'Alberto', 'Av. Santa Fe 1234', 'CABA', '1', 'Buenos Aires'],
+            ['2', 'María', 'Julia', 'Av. Santa Fe 1234', 'CABA', '1', 'Buenos Aires'],
+            ['3', 'Esther', 'Fermin', 'Av. Santa Fe 1234', 'CABA', '1', 'Buenos Aires']
+          ]}
+          bordered={true}
+        />
+      </div>
+    </div>
+  );
 };

--- a/src/scss/components/_nav.scss
+++ b/src/scss/components/_nav.scss
@@ -429,6 +429,8 @@ $icon-user-hover: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w
     align-items: center;
     justify-content: center;
     cursor: pointer;
+    padding: 0;
+    border: none;
 
     > span {
       font-size: 16px;

--- a/src/scss/components/_navbar.scss
+++ b/src/scss/components/_navbar.scss
@@ -1,7 +1,6 @@
 /* === Variable and mixins overides === */
 
-$navbar-padding: 0.75rem 1rem;
-$navbar-padding-y: spaceUnits(2);
+$navbar-padding-y: spaceUnits(3);
 $navbar-padding-y-desktop: spaceUnits(4.5);
 $navbar-brand-padding-y: 0;
 
@@ -261,7 +260,6 @@ $navbar-btn-icon-height: 40px;
 /* === Custom styles === */
 
 .navbar {
-  padding: $navbar-padding;
   .container {
     padding-left: 16px;
     padding-right: 16px;

--- a/src/scss/components/_navbar.scss
+++ b/src/scss/components/_navbar.scss
@@ -1,5 +1,6 @@
 /* === Variable and mixins overides === */
 
+$navbar-padding: 0.75rem 1rem;
 $navbar-padding-y: spaceUnits(2);
 $navbar-padding-y-desktop: spaceUnits(4.5);
 $navbar-brand-padding-y: 0;
@@ -260,6 +261,7 @@ $navbar-btn-icon-height: 40px;
 /* === Custom styles === */
 
 .navbar {
+  padding: $navbar-padding;
   .container {
     padding-left: 16px;
     padding-right: 16px;
@@ -535,13 +537,9 @@ $navbar-btn-icon-height: 40px;
     }
   }
 
-  #navbarBrand {
-    @include media-breakpoint-up(md) {
-      display: block;
-    }
-  }
-
-  #navbarToggler {
+  .navbar-brand.collapse.multi-collapse,
+  .collapse.multi-collapse:has(.form-search),
+  .collapse.multi-collapse:has(.navbar-toggler) {
     @include media-breakpoint-up(md) {
       .navbar-toggler {
         margin-right: 0px !important;
@@ -552,15 +550,9 @@ $navbar-btn-icon-height: 40px;
     }
   }
 
-  #navbarTogglerBack {
+  .navbar-btn-search .navbar-toggler.btn-icon {
     @include media-breakpoint-up(md) {
       display: none;
-    }
-  }
-
-  #navbarSearch {
-    @include media-breakpoint-up(md) {
-      display: block;
     }
   }
 

--- a/src/scss/components/_pagination.scss
+++ b/src/scss/components/_pagination.scss
@@ -152,6 +152,7 @@ $pagination-icon-left-active: url('data:image/svg+xml;utf8,<svg xmlns="http://ww
           $pagination-icon-left-active,
           $pagination-icon-right-active
         );
+        z-index: 0;
 
         &:hover,
         &.hover {

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -111,3 +111,9 @@ $table-striped-order: even;
     }
   }
 }
+
+.table-responsive, .table-responsive-sm, .table-responsive-md, .table-responsive-lg, .table-responsive-xl {
+  > .table-bordered {
+    border: $border-width solid $border-color;
+  }
+}


### PR DESCRIPTION
Fixes:

- fix paginacion: z-index cuando el item esta activo
- header: cambiar ids por clases en el scss
- Cuando el div contenedor de la tabla tenga la clase table-responsive no pierda el borde la tabla bordered
- Agregar en pestañas, que los botones para ir a derecha y a izquierda pueda usarse el tag y mantenga los mismos estilos , o cambiar directamente el html
- Correccion de url de 'Ver la documentación de componentes' en Inicio /Instalacion