### PR TITLE
fix: v1.55.1

### DIFF
--- a/src/components/Collapse/Collapse.stories.tsx
+++ b/src/components/Collapse/Collapse.stories.tsx
@@ -211,14 +211,6 @@ const CollapseForm = (): JSX.Element => (
       </div>
       <input type="radio" className="form-radio" name="credit_card" id="master" />
     </label>
-    <hr />
-    <label className="card-details" htmlFor="new_card">
-      <span className="material-icons-round">info</span>
-      <div className="card-details-content">
-        <h5>Nueva tarjeta de crédito</h5>
-      </div>
-      <input type="radio" className="form-radio" name="credit_card" id="new_card" />
-    </label>
   </form>
 );
 
@@ -240,14 +232,6 @@ const CollapseFormWhite = (): JSX.Element => (
         <small>Heraldo Paez</small>
       </div>
       <input type="radio" className="form-radio" name="credit_card" id="master_white" />
-    </label>
-    <hr />
-    <label className="card-details" htmlFor="new_card_white">
-      <span className="material-icons-round">info</span>
-      <div className="card-details-content">
-        <h5>Nueva tarjeta de crédito</h5>
-      </div>
-      <input type="radio" className="form-radio" name="credit_card" id="new_card_white" />
     </label>
   </form>
 );

--- a/src/organisms/Header/index.tsx
+++ b/src/organisms/Header/index.tsx
@@ -242,7 +242,7 @@ export const Header: React.FC<HeaderProps> = ({ hasLogin, hasProfile, hasSearch,
   return (
     <header className="navbar navbar-light navbar-expand-lg" role="banner">
       <a href="#main" className="skip-to-main-content-link">
-        Ir al contenido principal
+        Saltar al contenido principal
       </a>
       <div className="container header-container">
         {LOGO}

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -845,13 +845,14 @@ button.card {
         i,
         .material-icons-round {
           margin: auto 0;
-          font-size: 1.25rem;
+          font-size: 1.5rem;
         }
 
         .form-radio {
           cursor: pointer;
           margin-left: auto;
           width: 1.25rem;
+          min-width: 1.25rem;
           height: 1.25rem;
           appearance: none;
           background-color: $white;

--- a/src/scss/components/_navbar.scss
+++ b/src/scss/components/_navbar.scss
@@ -1033,6 +1033,25 @@ $navbar-toggle-menu: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/
 
           .dropdown {
             @include dropdown-states;
+            .btn-dropdown {
+              &:focus {
+                color: $grisulado-900;
+                .btn-dropdown-text {
+                  text-decoration: none;
+                }
+              }
+
+              &[aria-expanded='true'] {
+                color: $white;
+              }
+      
+              &:hover:not(:focus) {
+                box-shadow: 0 0 0 2px $blue;
+                .btn-dropdown-text {
+                  text-decoration: none;
+                }
+              }
+            }
           }
         }
 


### PR DESCRIPTION
**Header:**

- Link "skip-to-main-content-link": se reemplaza texto "Ir al contenido principal" por "Saltar al contenido principal"
- Boton de dropdown de perfil: se modifican estilos en estados hover y focus
![image](https://github.com/gcba/Obelisco/assets/60082396/baabef59-d887-428c-9551-ed96decde2d7)
https://github.com/gcba/estandares/issues/275#issuecomment-1783102853

**Colapsables:** 

- Se modifica icono de lista de radios a 24px
- Se elimina la opcion de 'nueva tarjeta de credito' en colapsable con lista seleccionable